### PR TITLE
Debug posthog ai module not found error

### DIFF
--- a/netlify/functions/generateFactoid.js
+++ b/netlify/functions/generateFactoid.js
@@ -1,7 +1,7 @@
 // netlify/functions/generateFactoid.js
 import 'dotenv/config';
 import OpenAI from 'openai';
-import { OpenAI as PostHogOpenAI } from '@posthog/ai/openai';
+import { OpenAI as PostHogOpenAI } from '@posthog/ai';
 import { PostHog } from 'posthog-node';
 import admin from 'firebase-admin';
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "andys-daily-factoids",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Fix `Runtime.ImportModuleError` in Netlify Functions by correcting the import path for `PostHogOpenAI`.

The original import `import { OpenAI as PostHogOpenAI } from '@posthog/ai/openai';` failed because the subpath export only provided `PostHogOpenAI` as a default export, not a named one, and was not correctly bundled by Netlify Functions. Switching to the main `@posthog/ai` package resolves this by using its named `OpenAI` export, which is compatible with the project's ES module configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-26cf543c-d2a6-4466-a0a3-7a1a5b7fd17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26cf543c-d2a6-4466-a0a3-7a1a5b7fd17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

