### PR TITLE
Update factoid generation cron job

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -60,7 +60,7 @@ services:
     name: hourly-factoid
     runtime: python
     plan: starter
-    schedule: "0 * * * *"
+    schedule: "*/30 * * * *"
     buildCommand: |
       pip install uv
       cd backend


### PR DESCRIPTION
Update the `hourly-factoid` cron job schedule to run every 30 minutes to generate factoids more frequently.

---
<a href="https://cursor.com/background-agent?bcId=bc-067c0942-9797-4a1a-a5de-3d7f1cd80f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-067c0942-9797-4a1a-a5de-3d7f1cd80f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

