### PR TITLE
Add 'Ask ChatGPT' button to factoid cards

### DIFF
--- a/frontend/src/components/__tests__/factoid-card.test.tsx
+++ b/frontend/src/components/__tests__/factoid-card.test.tsx
@@ -382,6 +382,41 @@ describe("FactoidCard", () => {
     });
   });
 
+  describe("Ask ChatGPT", () => {
+    it("should open ChatGPT with prompt in new window", () => {
+      const mockOpen = jest.fn();
+      window.open = mockOpen;
+
+      render(<FactoidCard factoid={defaultFactoid} initiallyExpanded={true} />);
+
+      const chatGPTButton = screen.getByLabelText(
+        "Ask ChatGPT if this factoid is true"
+      );
+      fireEvent.click(chatGPTButton);
+
+      const expectedPrompt = encodeURIComponent(
+        `Is this factoid true?\n${defaultFactoid.text}`
+      );
+      expect(mockOpen).toHaveBeenCalledWith(
+        `https://chat.openai.com/?q=${expectedPrompt}`,
+        "_blank",
+        "noopener,noreferrer"
+      );
+    });
+
+    it("should have proper button text and icon", () => {
+      render(<FactoidCard factoid={defaultFactoid} initiallyExpanded={true} />);
+
+      const chatGPTButton = screen.getByText("Ask ChatGPT");
+      expect(chatGPTButton).toBeInTheDocument();
+
+      // Check that the button has the correct aria-label
+      expect(
+        screen.getByLabelText("Ask ChatGPT if this factoid is true")
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("Chat Panel", () => {
     it("should open chat panel when chat button clicked", async () => {
       render(<FactoidCard factoid={defaultFactoid} initiallyExpanded={true} />);

--- a/frontend/src/components/factoid-card.tsx
+++ b/frontend/src/components/factoid-card.tsx
@@ -291,6 +291,12 @@ export function FactoidCard({
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
+  const handleAskChatGPT = () => {
+    const prompt = encodeURIComponent(`Is this factoid true?\n${factoid.text}`);
+    const url = `https://chat.openai.com/?q=${prompt}`;
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+
   const headlineText = isExpanded ? factoid.text : teaserText;
   const headerClasses = `flex gap-4${
     isExpanded ? " items-start" : " items-center justify-center text-center"
@@ -461,6 +467,28 @@ export function FactoidCard({
                     </svg>
                   </span>
                   this ASAP!
+                </button>
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleAskChatGPT();
+                  }}
+                  className="inline-flex items-center gap-2 rounded-full border border-emerald-200 px-3 py-1 text-emerald-700 hover:bg-emerald-50"
+                  aria-label="Ask ChatGPT if this factoid is true"
+                  title="Ask ChatGPT"
+                >
+                  <span aria-hidden className="flex items-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      className="h-4 w-4"
+                      fill="currentColor"
+                    >
+                      <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+                    </svg>
+                  </span>
+                  Ask ChatGPT
                 </button>
               </div>
               <div className="ml-auto flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Adds a new "Ask ChatGPT" button next to the existing "Google this ASAP!" button on factoid cards
- Button opens ChatGPT with a pre-filled prompt asking "Is this factoid true?" followed by the factoid text
- Uses the official ChatGPT SVG icon with an emerald color scheme to differentiate from other buttons

## Changes
- Added `handleAskChatGPT` function in `factoid-card.tsx` that constructs the ChatGPT URL with encoded prompt
- Added button UI with ChatGPT icon next to the Google search button
- Added comprehensive test coverage for the new button functionality

## Test plan
- [x] All existing tests pass
- [x] New tests added for ChatGPT button functionality
- [x] Manual testing: Button opens ChatGPT with correct prompt
- [x] Linting passes for both frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)