### PR TITLE
Add langfuse tracing support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-frontend install-backend install-precommit local local-backend local-frontend migrate-backend seed-backend run factoid test test-backend test-frontend test-rate-limit lint lint-backend lint-frontend precommit precommit-install precommit-run precommit-update smoke-backend-api test-generate-factoid test-braintrust test-braintrust-simple eval eval-structure eval-truthfulness eval-daily eval-install
+.PHONY: help install install-frontend install-backend install-precommit local local-backend local-frontend migrate-backend seed-backend run factoid test test-backend test-frontend test-rate-limit lint lint-backend lint-frontend precommit precommit-install precommit-run precommit-update smoke-backend-api test-generate-factoid test-braintrust test-braintrust-simple test-langfuse test-langfuse-simple eval eval-structure eval-truthfulness eval-daily eval-install
 
 help: ## Show available make targets
 	@awk -F ':.*## ' 'BEGIN {print "Available targets:"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -88,6 +88,12 @@ test-braintrust: ## Test Braintrust integration setup and configuration
 
 test-braintrust-simple: ## Test simple LangChain call with Braintrust tracing
 	cd backend && uv run python scripts/test_braintrust_simple.py
+
+test-langfuse: ## Test Langfuse integration with full factoid generation
+	cd backend && uv run python scripts/test_langfuse_integration.py
+
+test-langfuse-simple: ## Test simple LangChain call with Langfuse tracing
+	cd backend && uv run python scripts/test_langfuse_simple.py
 
 lint-frontend: ## Lint frontend files
 	@echo "Linting frontend files..."

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,3 +49,8 @@ DD_API_KEY=
 DD_SITE=datadoghq.com
 DD_LLMOBS_ENABLED=false
 DD_LLMOBS_ML_APP=andys-daily-factoids
+
+# Langfuse Tracing
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=https://cloud.langfuse.com

--- a/backend/apps/chat/services/factoid_agent.py
+++ b/backend/apps/chat/services/factoid_agent.py
@@ -27,6 +27,7 @@ from apps.core.braintrust import (
     log_operation_metadata,
 )
 from apps.core.datadog import get_datadog_callback_handler, initialize_datadog
+from apps.core.langfuse import get_langfuse_callback_handler, initialize_langfuse
 from apps.core.langsmith import get_langsmith_callback_handler, initialize_langsmith
 from apps.core.posthog import get_posthog_client
 from apps.factoids.models import Factoid
@@ -664,6 +665,14 @@ def _build_callbacks(
     datadog_callback = get_datadog_callback_handler()
     if datadog_callback:
         callbacks.append(datadog_callback)
+
+    # Initialize Langfuse tracing
+    initialize_langfuse()
+
+    # Optionally add a specific Langfuse callback for this chat session
+    langfuse_callback = get_langfuse_callback_handler()
+    if langfuse_callback:
+        callbacks.append(langfuse_callback)
 
     return callbacks
 

--- a/backend/apps/core/langfuse.py
+++ b/backend/apps/core/langfuse.py
@@ -1,0 +1,86 @@
+"""Langfuse integration for observability and tracing."""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from django.conf import settings
+
+try:
+    from langfuse import Langfuse
+    from langfuse.callback import CallbackHandler
+except ImportError:  # pragma: no cover - optional dependency
+    Langfuse = None  # type: ignore[assignment]
+    CallbackHandler = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+_client: Langfuse | None = None
+
+
+@lru_cache()
+def get_langfuse_client() -> Langfuse | None:
+    """Get a configured Langfuse client if available."""
+    global _client
+
+    if _client is not None:
+        return _client
+
+    if Langfuse is None:
+        logger.debug("Langfuse not available - install with 'pip install langfuse'")
+        return None
+
+    public_key = getattr(settings, "LANGFUSE_PUBLIC_KEY", None)
+    secret_key = getattr(settings, "LANGFUSE_SECRET_KEY", None)
+    host = getattr(settings, "LANGFUSE_HOST", "https://cloud.langfuse.com")
+
+    if not public_key or not secret_key:
+        logger.debug("Langfuse API keys not configured")
+        return None
+
+    try:
+        _client = Langfuse(
+            public_key=public_key,
+            secret_key=secret_key,
+            host=host,
+        )
+        logger.info("Langfuse client initialized successfully")
+        return _client
+    except Exception as e:
+        logger.warning("Failed to initialize Langfuse client: %s", e)
+        return None
+
+
+def get_langfuse_callback_handler() -> CallbackHandler | None:
+    """Get a Langfuse callback handler if Langfuse is configured."""
+    if CallbackHandler is None:
+        return None
+
+    # Ensure client is initialized
+    client = get_langfuse_client()
+    if not client:
+        return None
+
+    try:
+        return CallbackHandler()
+    except Exception as e:
+        logger.warning("Failed to initialize Langfuse callback handler: %s", e)
+        return None
+
+
+def initialize_langfuse() -> None:
+    """Initialize Langfuse tracing."""
+    client = get_langfuse_client()
+    if client:
+        logger.info("Langfuse tracing initialized")
+    else:
+        logger.debug("Langfuse tracing not initialized (not configured)")
+
+
+__all__ = [
+    "get_langfuse_client",
+    "get_langfuse_callback_handler",
+    "initialize_langfuse",
+]

--- a/backend/apps/core/langfuse.py
+++ b/backend/apps/core/langfuse.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 try:
     from langfuse import Langfuse
-    from langfuse.callback import CallbackHandler
+    from langfuse.langchain import CallbackHandler
 except ImportError:  # pragma: no cover - optional dependency
     Langfuse = None  # type: ignore[assignment]
     CallbackHandler = None  # type: ignore[assignment]

--- a/backend/apps/core/tests/test_langfuse.py
+++ b/backend/apps/core/tests/test_langfuse.py
@@ -1,0 +1,102 @@
+"""Tests for Langfuse integration."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from apps.core.langfuse import (
+    get_langfuse_callback_handler,
+    get_langfuse_client,
+    initialize_langfuse,
+)
+
+
+class TestLangfuseIntegration(TestCase):
+    """Test Langfuse observability integration."""
+
+    def test_get_langfuse_client_without_keys(self):
+        """Test that client returns None when API keys are not configured."""
+        with override_settings(LANGFUSE_PUBLIC_KEY=None, LANGFUSE_SECRET_KEY=None):
+            # Clear cache to get fresh initialization
+            get_langfuse_client.cache_clear()
+            client = get_langfuse_client()
+            self.assertIsNone(client)
+
+    def test_get_langfuse_callback_handler_without_client(self):
+        """Test that callback handler returns None when client is not available."""
+        with override_settings(LANGFUSE_PUBLIC_KEY=None, LANGFUSE_SECRET_KEY=None):
+            # Clear cache to get fresh initialization
+            get_langfuse_client.cache_clear()
+            handler = get_langfuse_callback_handler()
+            self.assertIsNone(handler)
+
+    @patch("apps.core.langfuse.Langfuse")
+    @patch("apps.core.langfuse.CallbackHandler")
+    def test_get_langfuse_client_with_keys(self, mock_callback_handler, mock_langfuse):
+        """Test that client is created when API keys are configured."""
+        mock_client = MagicMock()
+        mock_langfuse.return_value = mock_client
+
+        with override_settings(
+            LANGFUSE_PUBLIC_KEY="pk-test",
+            LANGFUSE_SECRET_KEY="sk-test",
+            LANGFUSE_HOST="https://cloud.langfuse.com",
+        ):
+            # Clear cache to get fresh initialization
+            get_langfuse_client.cache_clear()
+            client = get_langfuse_client()
+            self.assertIsNotNone(client)
+            self.assertEqual(client, mock_client)
+
+            # Verify Langfuse was called with correct parameters
+            mock_langfuse.assert_called_once_with(
+                public_key="pk-test",
+                secret_key="sk-test",
+                host="https://cloud.langfuse.com",
+            )
+
+    @patch("apps.core.langfuse.Langfuse")
+    @patch("apps.core.langfuse.CallbackHandler")
+    def test_get_langfuse_callback_handler_with_client(
+        self, mock_callback_handler_class, mock_langfuse
+    ):
+        """Test that callback handler is created when client is available."""
+        mock_client = MagicMock()
+        mock_langfuse.return_value = mock_client
+        mock_handler = MagicMock()
+        mock_callback_handler_class.return_value = mock_handler
+
+        with override_settings(
+            LANGFUSE_PUBLIC_KEY="pk-test",
+            LANGFUSE_SECRET_KEY="sk-test",
+            LANGFUSE_HOST="https://cloud.langfuse.com",
+        ):
+            # Clear cache to get fresh initialization
+            get_langfuse_client.cache_clear()
+            handler = get_langfuse_callback_handler()
+            self.assertIsNotNone(handler)
+            self.assertEqual(handler, mock_handler)
+
+            # Verify CallbackHandler was instantiated
+            mock_callback_handler_class.assert_called_once()
+
+    @patch("apps.core.langfuse.Langfuse", None)
+    @patch("apps.core.langfuse.CallbackHandler", None)
+    def test_initialize_langfuse_without_dependencies(self):
+        """Test that initialization fails gracefully when dependencies are missing."""
+        # Clear cache to get fresh initialization
+        get_langfuse_client.cache_clear()
+        initialize_langfuse()
+        # Should not raise any exceptions
+
+    def test_langfuse_integration_available(self):
+        """Test that Langfuse integration modules can be imported."""
+        try:
+            import langfuse  # noqa: F401
+            from langfuse.callback import CallbackHandler  # noqa: F401
+
+            # If we get here, the imports succeeded
+            self.assertTrue(True)
+        except ImportError:
+            # If imports fail, that's also valid (optional dependency)
+            self.assertTrue(True)

--- a/backend/apps/core/tests/test_langfuse.py
+++ b/backend/apps/core/tests/test_langfuse.py
@@ -14,22 +14,35 @@ from apps.core.langfuse import (
 class TestLangfuseIntegration(TestCase):
     """Test Langfuse observability integration."""
 
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("apps.core.langfuse.Langfuse", None)
+    @patch("apps.core.langfuse.CallbackHandler", None)
     def test_get_langfuse_client_without_keys(self):
         """Test that client returns None when API keys are not configured."""
         with override_settings(LANGFUSE_PUBLIC_KEY=None, LANGFUSE_SECRET_KEY=None):
-            # Clear cache to get fresh initialization
+            # Clear cache and reset global client to get fresh initialization
             get_langfuse_client.cache_clear()
+            import apps.core.langfuse
+
+            apps.core.langfuse._client = None
             client = get_langfuse_client()
             self.assertIsNone(client)
 
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("apps.core.langfuse.Langfuse", None)
+    @patch("apps.core.langfuse.CallbackHandler", None)
     def test_get_langfuse_callback_handler_without_client(self):
         """Test that callback handler returns None when client is not available."""
         with override_settings(LANGFUSE_PUBLIC_KEY=None, LANGFUSE_SECRET_KEY=None):
-            # Clear cache to get fresh initialization
+            # Clear cache and reset global client to get fresh initialization
             get_langfuse_client.cache_clear()
+            import apps.core.langfuse
+
+            apps.core.langfuse._client = None
             handler = get_langfuse_callback_handler()
             self.assertIsNone(handler)
 
+    @patch.dict("os.environ", {}, clear=True)
     @patch("apps.core.langfuse.Langfuse")
     @patch("apps.core.langfuse.CallbackHandler")
     def test_get_langfuse_client_with_keys(self, mock_callback_handler, mock_langfuse):
@@ -42,8 +55,11 @@ class TestLangfuseIntegration(TestCase):
             LANGFUSE_SECRET_KEY="sk-test",
             LANGFUSE_HOST="https://cloud.langfuse.com",
         ):
-            # Clear cache to get fresh initialization
+            # Clear cache and reset global client to get fresh initialization
             get_langfuse_client.cache_clear()
+            import apps.core.langfuse
+
+            apps.core.langfuse._client = None
             client = get_langfuse_client()
             self.assertIsNotNone(client)
             self.assertEqual(client, mock_client)
@@ -93,7 +109,7 @@ class TestLangfuseIntegration(TestCase):
         """Test that Langfuse integration modules can be imported."""
         try:
             import langfuse  # noqa: F401
-            from langfuse.callback import CallbackHandler  # noqa: F401
+            from langfuse.langchain import CallbackHandler  # noqa: F401
 
             # If we get here, the imports succeeded
             self.assertTrue(True)

--- a/backend/apps/factoids/services/generator.py
+++ b/backend/apps/factoids/services/generator.py
@@ -16,6 +16,7 @@ from apps.core.braintrust import (
     log_operation_metadata,
 )
 from apps.core.datadog import get_datadog_callback_handler, initialize_datadog
+from apps.core.langfuse import get_langfuse_callback_handler, initialize_langfuse
 from apps.core.langsmith import get_langsmith_callback_handler, initialize_langsmith
 from apps.core.posthog import get_posthog_client
 from apps.core.services import (
@@ -231,6 +232,14 @@ def _build_callbacks(
     datadog_callback = get_datadog_callback_handler()
     if datadog_callback:
         callbacks.append(datadog_callback)
+
+    # Initialize Langfuse tracing
+    initialize_langfuse()
+
+    # Optionally add a specific Langfuse callback for this generation
+    langfuse_callback = get_langfuse_callback_handler()
+    if langfuse_callback:
+        callbacks.append(langfuse_callback)
 
     return callbacks
 

--- a/backend/apps/factoids/tests/test_services.py
+++ b/backend/apps/factoids/tests/test_services.py
@@ -221,11 +221,19 @@ def test_model_supports_tools_returns_false_when_fetch_fails(mock_fetch):
 @patch("apps.factoids.services.generator.CallbackHandler")
 @patch("apps.factoids.services.generator.initialize_braintrust")
 @patch("apps.factoids.services.generator.initialize_langsmith")
+@patch("apps.factoids.services.generator.initialize_datadog")
+@patch("apps.factoids.services.generator.initialize_langfuse")
 @patch("apps.factoids.services.generator.get_braintrust_callback_handler")
 @patch("apps.factoids.services.generator.get_langsmith_callback_handler")
+@patch("apps.factoids.services.generator.get_datadog_callback_handler")
+@patch("apps.factoids.services.generator.get_langfuse_callback_handler")
 def test_build_callbacks_uses_distinct_id_and_properties(
+    mock_langfuse_handler,
+    mock_datadog_handler,
     mock_langsmith_handler,
     mock_braintrust_handler,
+    mock_init_langfuse,
+    mock_init_datadog,
     mock_init_langsmith,
     mock_init_braintrust,
     mock_handler,
@@ -234,6 +242,8 @@ def test_build_callbacks_uses_distinct_id_and_properties(
     mock_handler.return_value = MagicMock()
     mock_braintrust_handler.return_value = None
     mock_langsmith_handler.return_value = None
+    mock_datadog_handler.return_value = None
+    mock_langfuse_handler.return_value = None
 
     callbacks = _build_callbacks(
         posthog_client,

--- a/backend/factoids_project/settings/base.py
+++ b/backend/factoids_project/settings/base.py
@@ -163,6 +163,11 @@ DATADOG_SITE = settings.datadog_site
 DATADOG_LLMOBS_ENABLED = settings.datadog_llmobs_enabled
 DATADOG_LLMOBS_ML_APP = settings.datadog_llmobs_ml_app
 
+# Langfuse configuration
+LANGFUSE_PUBLIC_KEY = settings.langfuse_public_key
+LANGFUSE_SECRET_KEY = settings.langfuse_secret_key
+LANGFUSE_HOST = settings.langfuse_host
+
 STRIPE_SECRET_KEY = settings.stripe_secret_key
 STRIPE_PUBLISHABLE_KEY = settings.stripe_publishable_key
 STRIPE_PRICE_ID = settings.stripe_price_id

--- a/backend/factoids_project/settings/config.py
+++ b/backend/factoids_project/settings/config.py
@@ -116,6 +116,18 @@ class AppSettings(BaseSettings):
             "DD_LLMOBS_ML_APP", "DATADOG_LLMOBS_ML_APP", "DJANGO_DATADOG_LLMOBS_ML_APP"
         ),
     )
+    langfuse_public_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("LANGFUSE_PUBLIC_KEY", "DJANGO_LANGFUSE_PUBLIC_KEY"),
+    )
+    langfuse_secret_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("LANGFUSE_SECRET_KEY", "DJANGO_LANGFUSE_SECRET_KEY"),
+    )
+    langfuse_host: str = Field(
+        default="https://cloud.langfuse.com",
+        validation_alias=AliasChoices("LANGFUSE_HOST", "DJANGO_LANGFUSE_HOST"),
+    )
     stripe_secret_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices("STRIPE_SECRET_KEY", "DJANGO_STRIPE_SECRET_KEY"),
@@ -358,6 +370,18 @@ def get_settings(env_file: str | os.PathLike[str] | None = None) -> AppSettings:
                         or os.getenv("DD_LLMOBS_ML_APP")
                         or os.getenv("DATADOG_LLMOBS_ML_APP")
                         or "andys-daily-factoids"
+                    )
+
+                    self.langfuse_public_key = os.getenv(
+                        "DJANGO_LANGFUSE_PUBLIC_KEY"
+                    ) or os.getenv("LANGFUSE_PUBLIC_KEY")
+                    self.langfuse_secret_key = os.getenv(
+                        "DJANGO_LANGFUSE_SECRET_KEY"
+                    ) or os.getenv("LANGFUSE_SECRET_KEY")
+                    self.langfuse_host = (
+                        os.getenv("DJANGO_LANGFUSE_HOST")
+                        or os.getenv("LANGFUSE_HOST")
+                        or "https://cloud.langfuse.com"
                     )
 
                     self.stripe_secret_key = os.getenv("DJANGO_STRIPE_SECRET_KEY") or os.getenv(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "braintrust-langchain>=0.0.4",
     "langsmith>=0.1.149",
     "ddtrace>=2.14.0",
+    "langfuse>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/scripts/test_langfuse_integration.py
+++ b/backend/scripts/test_langfuse_integration.py
@@ -58,7 +58,7 @@ def main():
             posthog_distinct_id="test-langfuse",
         )
 
-        print(f"✅ Factoid generated successfully!")
+        print("✅ Factoid generated successfully!")
         print(f"   Emoji: {factoid.emoji}")
         print(f"   Subject: {factoid.subject}")
         print(f"   Text: {factoid.text[:100]}...")

--- a/backend/scripts/test_langfuse_integration.py
+++ b/backend/scripts/test_langfuse_integration.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Test Langfuse integration with the full factoid generation service."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add the backend directory to Python path
+backend_dir = Path(__file__).parent.parent
+sys.path.insert(0, str(backend_dir))
+
+# Set up Django environment
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "factoids_project.settings.local")
+
+import django  # noqa: E402
+
+django.setup()
+
+from apps.core.langfuse import get_langfuse_client, initialize_langfuse  # noqa: E402
+from apps.factoids.services.generator import generate_factoid  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+
+def main():
+    """Test factoid generation with Langfuse tracing."""
+    print("🧪 Testing Factoid Generation + Langfuse Integration")
+    print("=" * 60)
+
+    # Initialize Langfuse
+    initialize_langfuse()
+    client = get_langfuse_client()
+
+    if not client:
+        print("❌ Failed to initialize Langfuse")
+        print("   Please ensure LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are set")
+        return False
+
+    print("✅ Langfuse client initialized")
+
+    # Check if we have OpenRouter API key
+    api_key = getattr(settings, "OPENROUTER_API_KEY", None)
+    if not api_key:
+        print("❌ OPENROUTER_API_KEY not configured")
+        return False
+
+    print("✅ OpenRouter API key found")
+
+    try:
+        # Generate a factoid
+        print("\n🔄 Generating factoid...")
+        
+        factoid = generate_factoid(
+            topic="artificial intelligence",
+            model_key="openai/gpt-3.5-turbo",
+            temperature=0.7,
+            client_hash="test-langfuse-integration",
+            profile="api_key",  # Use api_key profile for higher rate limits
+            posthog_distinct_id="test-langfuse",
+        )
+
+        print(f"✅ Factoid generated successfully!")
+        print(f"   Emoji: {factoid.emoji}")
+        print(f"   Subject: {factoid.subject}")
+        print(f"   Text: {factoid.text[:100]}...")
+        
+        # Flush the Langfuse client to ensure traces are sent
+        if client:
+            client.flush()
+            print("\n✅ Flushed Langfuse traces")
+
+        print("\n🎉 Success! Check your Langfuse dashboard for the trace:")
+        print(f"   - Visit: {settings.LANGFUSE_HOST}")
+        print("   - Project: andys-daily-factoids")
+        print("   - Look for the trace with generation_request_id")
+        print(f"   - Generation Request ID: {factoid.created_by.id}")
+
+        return True
+
+    except Exception as e:
+        print(f"❌ Factoid generation failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)

--- a/backend/scripts/test_langfuse_simple.py
+++ b/backend/scripts/test_langfuse_simple.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Simple test to verify Langfuse is capturing LangChain calls."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add the backend directory to Python path
+backend_dir = Path(__file__).parent.parent
+sys.path.insert(0, str(backend_dir))
+
+# Set up Django environment
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "factoids_project.settings.local")
+
+import django  # noqa: E402
+
+django.setup()
+
+from apps.core.langfuse import (  # noqa: E402
+    get_langfuse_callback_handler,
+    get_langfuse_client,
+    initialize_langfuse,
+)
+from django.conf import settings  # noqa: E402
+from langchain_core.messages import HumanMessage  # noqa: E402
+from langchain_openai import ChatOpenAI  # noqa: E402
+
+
+async def main():
+    """Test simple LangChain call with Langfuse."""
+    print("🧪 Testing Simple LangChain + Langfuse Integration")
+    print("=" * 55)
+
+    # Initialize Langfuse
+    initialize_langfuse()
+    client = get_langfuse_client()
+    
+    if not client:
+        print("❌ Failed to initialize Langfuse")
+        print("   Please ensure LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are set")
+        return False
+
+    print("✅ Langfuse initialized successfully")
+
+    # Check if we have OpenRouter API key
+    api_key = getattr(settings, "OPENROUTER_API_KEY", None)
+    if not api_key:
+        print("❌ OPENROUTER_API_KEY not configured")
+        return False
+
+    print("✅ OpenRouter API key found")
+
+    # Create a simple ChatOpenAI model
+    model = ChatOpenAI(
+        api_key=api_key,
+        base_url=settings.OPENROUTER_BASE_URL.rstrip("/"),
+        model="openai/gpt-3.5-turbo",
+        temperature=0.7,
+    )
+
+    print("✅ ChatOpenAI model created")
+
+    # Get Langfuse callback handler
+    langfuse_handler = get_langfuse_callback_handler()
+    callbacks = [langfuse_handler] if langfuse_handler else []
+
+    print(f"✅ Callbacks prepared: {len(callbacks)} handlers")
+
+    try:
+        # Make a simple LLM call
+        print("\n🔄 Making LLM call...")
+
+        message = HumanMessage(content="What is 2 + 2? Answer in one sentence.")
+        response = model.invoke([message], config={"callbacks": callbacks})
+
+        print(f"✅ LLM Response: {response.content}")
+        
+        # Flush the Langfuse client to ensure traces are sent
+        if client:
+            client.flush()
+            print("✅ Flushed Langfuse traces")
+        
+        print("\n🎉 Success! Check your Langfuse dashboard for the trace:")
+        print(f"   - Visit: {settings.LANGFUSE_HOST}")
+        print("   - Project: andys-daily-factoids")
+        print("   - Look for recent traces")
+
+        return True
+
+    except Exception as e:
+        print(f"❌ LLM call failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    success = asyncio.run(main())
+    sys.exit(0 if success else 1)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -134,6 +134,7 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-openai" },
     { name = "langchain-tavily" },
+    { name = "langfuse" },
     { name = "langgraph" },
     { name = "langsmith" },
     { name = "openai" },
@@ -174,6 +175,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=0.3.0,<0.4.0" },
     { name = "langchain-openai", specifier = ">=0.2.0,<0.3.0" },
     { name = "langchain-tavily", specifier = ">=0.1.0" },
+    { name = "langfuse", specifier = ">=2.0.0" },
     { name = "langgraph", specifier = ">=0.1.0" },
     { name = "langsmith", specifier = ">=0.1.149" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9,<2.0" },
@@ -786,6 +788,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530, upload-time = "2025-04-14T10:17:01.271Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1089,6 +1103,26 @@ wheels = [
 ]
 
 [[package]]
+name = "langfuse"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/ea/b1abad97af5e4dba0ea3135387efa139f11ac34e57da5a8b2ea14354bd95/langfuse-3.6.1.tar.gz", hash = "sha256:eac27ee5bbd8d05e7d665e822e0efb36766b20fe281930ff040f47eb22cc1b69", size = 189456, upload-time = "2025-10-02T08:33:17.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/49/4eae7cd4a1005c77808b3d8e3174412c4e198c8fb776b8847b0223a5f504/langfuse-3.6.1-py3-none-any.whl", hash = "sha256:134e0007fcfdd9fb70b491c882bb431c8095b3f5cc5e865756f46a2abd3675a2", size = 350756, upload-time = "2025-10-02T08:33:15.607Z" },
+]
+
+[[package]]
 name = "langgraph"
 version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1366,6 +1400,75 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/04/05040d7ce33a907a2a02257e601992f0cdf11c73b33f13c4492bf6c3d6d5/opentelemetry_api-1.37.0.tar.gz", hash = "sha256:540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7", size = 64923, upload-time = "2025-09-11T10:29:01.662Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/48/28ed9e55dcf2f453128df738210a980e09f4e468a456fa3c763dbc8be70a/opentelemetry_api-1.37.0-py3-none-any.whl", hash = "sha256:accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47", size = 65732, upload-time = "2025-09-11T10:28:41.826Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/6c/10018cbcc1e6fff23aac67d7fd977c3d692dbe5f9ef9bb4db5c1268726cc/opentelemetry_exporter_otlp_proto_common-1.37.0.tar.gz", hash = "sha256:c87a1bdd9f41fdc408d9cc9367bb53f8d2602829659f2b90be9f9d79d0bfe62c", size = 20430, upload-time = "2025-09-11T10:29:03.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/13/b4ef09837409a777f3c0af2a5b4ba9b7af34872bc43609dda0c209e4060d/opentelemetry_exporter_otlp_proto_common-1.37.0-py3-none-any.whl", hash = "sha256:53038428449c559b0c564b8d718df3314da387109c4d36bd1b94c9a641b0292e", size = 18359, upload-time = "2025-09-11T10:28:44.939Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/e3/6e320aeb24f951449e73867e53c55542bebbaf24faeee7623ef677d66736/opentelemetry_exporter_otlp_proto_http-1.37.0.tar.gz", hash = "sha256:e52e8600f1720d6de298419a802108a8f5afa63c96809ff83becb03f874e44ac", size = 17281, upload-time = "2025-09-11T10:29:04.844Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/e9/70d74a664d83976556cec395d6bfedd9b85ec1498b778367d5f93e373397/opentelemetry_exporter_otlp_proto_http-1.37.0-py3-none-any.whl", hash = "sha256:54c42b39945a6cc9d9a2a33decb876eabb9547e0dcb49df090122773447f1aef", size = 19576, upload-time = "2025-09-11T10:28:46.726Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/ea/a75f36b463a36f3c5a10c0b5292c58b31dbdde74f6f905d3d0ab2313987b/opentelemetry_proto-1.37.0.tar.gz", hash = "sha256:30f5c494faf66f77faeaefa35ed4443c5edb3b0aa46dad073ed7210e1a789538", size = 46151, upload-time = "2025-09-11T10:29:11.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/25/f89ea66c59bd7687e218361826c969443c4fa15dfe89733f3bf1e2a9e971/opentelemetry_proto-1.37.0-py3-none-any.whl", hash = "sha256:8ed8c066ae8828bbf0c39229979bdf583a126981142378a9cbe9d6fd5701c6e2", size = 72534, upload-time = "2025-09-11T10:28:56.831Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/62/2e0ca80d7fe94f0b193135375da92c640d15fe81f636658d2acf373086bc/opentelemetry_sdk-1.37.0.tar.gz", hash = "sha256:cc8e089c10953ded765b5ab5669b198bbe0af1b3f89f1007d19acd32dc46dda5", size = 170404, upload-time = "2025-09-11T10:29:11.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/62/9f4ad6a54126fb00f7ed4bb5034964c6e4f00fcd5a905e115bd22707e20d/opentelemetry_sdk-1.37.0-py3-none-any.whl", hash = "sha256:8f3c3c22063e52475c5dbced7209495c2c16723d016d39287dfc215d1771257c", size = 131941, upload-time = "2025-09-11T10:28:57.83Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867, upload-time = "2025-09-11T10:29:12.597Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954, upload-time = "2025-09-11T10:28:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Langfuse tracing support out-of-the-box, similar to existing observability tools, to enable detailed LLM call monitoring.

This PR introduces a new `langfuse.py` module for client and callback handler management, integrates Langfuse into the factoid generation service, and includes two smoke test scripts (`test_langfuse_simple.py` and `test_langfuse_integration.py`) to validate the setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-9845112f-2542-45ba-8644-41fd150e853d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9845112f-2542-45ba-8644-41fd150e853d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional Langfuse observability and tracing for generation and chat flows, with graceful fallback when not configured.

- **Tests**
  - Added unit tests for Langfuse integration and scripts for simple and end-to-end Langfuse verification.

- **Chores**
  - Added example environment variables for Langfuse, new Make targets to run verification scripts, and a Langfuse dependency.

- **Refactor**
  - Integrated Langfuse tracing callbacks into existing callback construction without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->